### PR TITLE
Remove rollup binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Plataforma inteligente de seguimiento de salud infantil con IA avanzada y funcionalidad offline completa**
 
-![Version](https://img.shields.io/badge/version-2.5.1-blue.svg)
+![Version](https://img.shields.io/badge/version-2.5.2-blue.svg)
 ![React](https://img.shields.io/badge/React-19.1.0-61dafb.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-3178c6.svg)
 ![PWA](https://img.shields.io/badge/PWA-Ready-orange.svg)
@@ -78,6 +78,14 @@ cd chimuelo-health-tracker
 ./start_platform.sh setup    # Solo instalar dependencias
 ./start_platform.sh worker   # Configurar Cloudflare Worker
 ```
+
+Luego instala las dependencias ejecutando:
+
+```bash
+npm ci --omit=optional
+```
+
+El proyecto utiliza la versión WASM de Rollup para evitar binarios específicos de plataforma.
 
 La aplicación estará disponible en: **http://localhost:5173**
 
@@ -227,7 +235,7 @@ test: tests para el service worker
 
 ## 📋 Roadmap de Desarrollo
 
-### ✅ Completado (v2.5.1)
+### ✅ Completado (v2.5.2)
 - ✅ Sistema de temas completamente funcional
 - ✅ Worker de Cloudflare con OpenAI completo
 - ✅ Timeline con error boundary y skeleton loading

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",
         "ajv": "^8.17.1",
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@rollup/wasm-node": "^4.46.1",
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -1181,160 +1182,6 @@
         "freebsd"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.1.tgz",
-      "integrity": "sha512-K4ncpWl7sQuyp6rWiGUvb6Q18ba8mzM0rjWJ5JgYKlIXAau1db7hZnR0ldJvqKWWJDxqzSLwGUhA4jp+KqgDtQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.1.tgz",
-      "integrity": "sha512-YykPnXsjUjmXE6j6k2QBBGAn1YsJUix7pYaPLK3RVE0bQL2jfdbfykPxfF8AgBlqtYbfEnYHmLXNa6QETjdOjQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.1.tgz",
-      "integrity": "sha512-kKvqBGbZ8i9pCGW3a1FH3HNIVg49dXXTsChGFsHGXQaVJPLA4f/O+XmTxfklhccxdF5FefUn2hvkoGJH0ScWOA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.1.tgz",
-      "integrity": "sha512-zzX5nTw1N1plmqC9RGC9vZHFuiM7ZP7oSWQGqpbmfjK7p947D518cVK1/MQudsBdcD84t6k70WNczJOct6+hdg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.1.tgz",
-      "integrity": "sha512-O8CwgSBo6ewPpktFfSDgB6SJN9XDcPSvuwxfejiddbIC/hn9Tg6Ai0f0eYDf3XvB/+PIWzOQL+7+TZoB8p9Yuw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.1.tgz",
-      "integrity": "sha512-JnCfFVEKeq6G3h3z8e60kAp8Rd7QVnWCtPm7cxx+5OtP80g/3nmPtfdCXbVl063e3KsRnGSKDHUQMydmzc/wBA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.1.tgz",
-      "integrity": "sha512-dVxuDqS237eQXkbYzQQfdf/njgeNw6LZuVyEdUaWwRpKHhsLI+y4H/NJV8xJGU19vnOJCVwaBFgr936FHOnJsQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.1.tgz",
-      "integrity": "sha512-CvvgNl2hrZrTR9jXK1ye0Go0HQRT6ohQdDfWR47/KFKiLd5oN5T14jRdUVGF4tnsN8y9oSfMOqH6RuHh+ck8+w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.1.tgz",
-      "integrity": "sha512-x7ANt2VOg2565oGHJ6rIuuAon+A8sfe1IeUx25IKqi49OjSr/K3awoNqr9gCwGEJo9OuXlOn+H2p1VJKx1psxA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.1.tgz",
-      "integrity": "sha512-9OADZYryz/7E8/qt0vnaHQgmia2Y0wrjSSn1V/uL+zw/i7NUhxbX4cHXdEQ7dnJgzYDS81d8+tf6nbIdRFZQoQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.46.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.1.tgz",
-      "integrity": "sha512-NuvSCbXEKY+NGWHyivzbjSVJi68Xfq1VnIvGmsuXs6TCtveeoDRKutI5vf2ntmNnVq64Q4zInet0UDQ+yMB6tA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.46.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.1.tgz",
@@ -1376,6 +1223,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@rollup/wasm-node": {
+      "version": "4.46.1",
+      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.46.1.tgz",
+      "integrity": "sha512-3vOhhqH3c3YJoIvyHsAOqdnH8KOl+LhvVjyfzd/BI1RvhnfA3RMRCporxlQCriUtEoA1JzCok1UWDrMqj5nejQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3113,17 +2980,6 @@
         "@rollup/rollup-darwin-x64": "4.46.1",
         "@rollup/rollup-freebsd-arm64": "4.46.1",
         "@rollup/rollup-freebsd-x64": "4.46.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.46.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.46.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.46.1",
-        "@rollup/rollup-linux-arm64-musl": "4.46.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.46.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.46.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.46.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.46.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.46.1",
-        "@rollup/rollup-linux-x64-gnu": "4.46.1",
-        "@rollup/rollup-linux-x64-musl": "4.46.1",
         "@rollup/rollup-win32-arm64-msvc": "4.46.1",
         "@rollup/rollup-win32-ia32-msvc": "4.46.1",
         "@rollup/rollup-win32-x64-msvc": "4.46.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "version:patch": "npm version patch --no-git-tag-version",
     "version:minor": "npm version minor --no-git-tag-version",
-    "version:major": "npm version major --no-git-tag-version"
+    "version:major": "npm version major --no-git-tag-version",
+    "postinstall": "node scripts/setup-rollup-wasm.cjs"
   },
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
@@ -33,6 +34,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "@rollup/wasm-node": "^4.46.1"
   }
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Chimuelo Health Tracker",
   "short_name": "Chimuelo",
   "description": "Aplicación inteligente para el seguimiento de la salud de tu bebé con IA avanzada",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "start_url": "/chimuelo/",
   "scope": "/chimuelo/",
   "display": "standalone",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker para Chimuelo Health Tracker PWA
 // Versión del cache - incrementar para forzar actualización
-const CACHE_VERSION = 'chimuelo-v2.5.1';
+const CACHE_VERSION = 'chimuelo-v2.5.2';
 const CACHE_NAME = `chimuelo-cache-${CACHE_VERSION}`;
 
 // Archivos críticos a cachear

--- a/frontend/scripts/setup-rollup-wasm.cjs
+++ b/frontend/scripts/setup-rollup-wasm.cjs
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+const targetDir = path.join(__dirname, '..', 'node_modules', '@rollup', 'rollup-linux-x64-gnu');
+if (!fs.existsSync(targetDir)) {
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+fs.writeFileSync(path.join(targetDir, 'index.js'), "module.exports = require('@rollup/wasm-node/dist/native.js');\n");
+fs.writeFileSync(path.join(targetDir, 'package.json'), JSON.stringify({name:'@rollup/rollup-linux-x64-gnu',version:'4.46.1',main:'index.js'}, null, 2));

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -608,7 +608,7 @@ const Settings: React.FC = () => {
                 <div className="app-info">
                   <div className="app-icon">👶</div>
                   <h3>Chimuelo Health Tracker</h3>
-                  <p className="version">Versión 2.5.1</p>
+                  <p className="version">Versión 2.5.2</p>
                 </div>
 
                 <div className="about-description">


### PR DESCRIPTION
## Summary
- trim rollup-linux entries from package-lock
- use Rollup wasm build and add postinstall script for stub
- document install instructions and bump version

## Testing
- `npm ci --omit=optional`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68891f4cedd88324881618f9bec6c777