### PR TITLE
Fix npm ci lock file mismatch

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "2.5.6",
+      "hasInstallScript": true,
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",
         "ajv": "^8.17.1",
@@ -518,29 +519,25 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.46.1",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@rollup/wasm-node": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.46.2.tgz",
+      "integrity": "sha512-lZRiZl+B1R3VhqZgORtuUpc2YYbgIv+X6g3LgQHS5sjlf1ENiK1HZ6N5e8pEZ04nAWiwYM0JX7rP0eyxflkJRg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.46.1",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1568,6 +1565,21 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",


### PR DESCRIPTION
## Summary
- sync `frontend/package-lock.json` to fix `npm ci` error

## Testing
- `npm run build` in `frontend`
- `npm test` in `worker` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6889534c56a08324925c50ad5d3df879