### PR TITLE
Fix multi-agent fallback and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Plataforma inteligente de seguimiento de salud infantil con IA avanzada y funcionalidad offline completa**
 
-![Version](https://img.shields.io/badge/version-2.5.7-blue.svg)
+![Version](https://img.shields.io/badge/version-2.5.8-blue.svg)
 ![React](https://img.shields.io/badge/React-19.1.0-61dafb.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-3178c6.svg)
 ![PWA](https://img.shields.io/badge/PWA-Ready-orange.svg)
@@ -235,7 +235,7 @@ test: tests para el service worker
 
 ## 📋 Roadmap de Desarrollo
 
-### ✅ Completado (v2.5.7)
+### ✅ Completado (v2.5.8)
 - ✅ Sistema de temas completamente funcional
 - ✅ Worker de Cloudflare con OpenAI completo
 - ✅ Timeline con error boundary y skeleton loading

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,4 +4,4 @@ VITE_WORKER_URL=https://your-worker-url.workers.dev
 
 # Application Configuration
 VITE_APP_NAME=Chimuelo Health Tracker
-VITE_APP_VERSION=2.5.7
+VITE_APP_VERSION=2.5.8

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "hasInstallScript": true,
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Chimuelo Health Tracker",
   "short_name": "Chimuelo",
   "description": "Aplicación inteligente para el seguimiento de la salud de tu bebé con IA avanzada",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "start_url": "/chimuelo/",
   "scope": "/chimuelo/",
   "display": "standalone",

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker para Chimuelo Health Tracker PWA
 // Versión del cache - incrementar para forzar actualización
-const CACHE_VERSION = 'chimuelo-v2.5.7';
+const CACHE_VERSION = 'chimuelo-v2.5.8';
 const CACHE_NAME = `chimuelo-cache-${CACHE_VERSION}`;
 
 // Archivos críticos a cachear


### PR DESCRIPTION
## Summary
- enable local multi-agent fallback when OpenAI fails
- return agent responses and related info from multi-agent coordinator
- bump version to 2.5.8 across project

## Testing
- `npm test` in `worker`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68896141c7848324a644e260aed8282b