### PR TITLE
Improve mobile-first styling with Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Plataforma inteligente de seguimiento de salud infantil con IA avanzada y funcionalidad offline completa**
 
-![Version](https://img.shields.io/badge/version-2.5.7-blue.svg)
+![Version](https://img.shields.io/badge/version-2.5.8-blue.svg)
 ![React](https://img.shields.io/badge/React-19.1.0-61dafb.svg)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-3178c6.svg)
 ![PWA](https://img.shields.io/badge/PWA-Ready-orange.svg)
@@ -235,7 +235,7 @@ test: tests para el service worker
 
 ## 📋 Roadmap de Desarrollo
 
-### ✅ Completado (v2.5.7)
+### ✅ Completado (v2.5.8)
 - ✅ Sistema de temas completamente funcional
 - ✅ Worker de Cloudflare con OpenAI completo
 - ✅ Timeline con error boundary y skeleton loading

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "private": true,
   "type": "module",
   "scripts": {
@@ -35,6 +35,9 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",
-    "@rollup/wasm-node": "^4.46.1"
+    "@rollup/wasm-node": "^4.46.1",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import MedicalFile from './pages/MedicalFile';
 import Chat from './pages/Chat';
 import Settings from './pages/Settings';
 import Profile from './pages/Profile';
+import './styles/tailwind.css';
 import './App.css';
 import './styles/themes.css';
 import './styles/ErrorBoundary.css';

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,7 +3,6 @@ import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import Logo from '../components/Logo';
 import AppFooter from '../components/AppFooter';
-import '../styles/Auth.css';
 
 const Login: React.FC = () => {
   if (import.meta.env.VITE_DEV === 'TRUE') {
@@ -117,77 +116,33 @@ const Login: React.FC = () => {
   const isFormValid = formData.email && formData.password.length >= 6;
 
   return (
-    <div className="auth-container">
-      <div className="auth-card">
-        <div className="auth-header">
-                <div className="auth-logo">
-        <Logo size="large" variant="animated" />
-        <h1 className="logo-title">Chimuelo</h1>
-      </div>
-          <p className="auth-subtitle">Inicia sesión en tu cuenta</p>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-zinc-900 p-4">
+      <div className="w-full max-w-sm bg-white dark:bg-zinc-800 rounded-2xl shadow-lg p-6">
+        <div className="flex flex-col items-center gap-2 mb-6">
+          <Logo size="large" variant="animated" />
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Chimuelo</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Inicia sesión en tu cuenta</p>
         </div>
-
-        <form className="auth-form" onSubmit={handleSubmit}>
-          <div className="form-group">
-            <label htmlFor="email" className="form-label">
-              Email
-            </label>
-            <input
-              type="email"
-              id="email"
-              name="email"
-              value={formData.email}
-              onChange={handleChange}
-              className="form-input"
-              placeholder="tu@email.com"
-              required
-              autoComplete="email"
-              autoFocus
-            />
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input type="email" id="email" name="email" value={formData.email} onChange={handleChange} className="w-full rounded-lg border border-gray-300 dark:border-gray-600 p-3" placeholder="tu@email.com" required autoComplete="email" autoFocus />
           </div>
-
-          <div className="form-group">
-            <label htmlFor="password" className="form-label">
-              Contraseña
-            </label>
-            <div className="password-input-container">
-              <input
-                type={showPassword ? 'text' : 'password'}
-                id="password"
-                name="password"
-                value={formData.password}
-                onChange={handleChange}
-                className="form-input"
-                placeholder="Min. 6 caracteres"
-                required
-                autoComplete="current-password"
-              />
-              <button
-                type="button"
-                className="password-toggle"
-                onClick={() => setShowPassword(!showPassword)}
-                aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-              >
-                {showPassword ? '🙈' : '👁️'}
-              </button>
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm font-medium text-gray-700 dark:text-gray-300">Contraseña</label>
+            <div className="relative">
+              <input type={showPassword ? 'text' : 'password'} id="password" name="password" value={formData.password} onChange={handleChange} className="w-full rounded-lg border border-gray-300 dark:border-gray-600 p-3 pr-10" placeholder="Min. 6 caracteres" required autoComplete="current-password" />
+              <button type="button" className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 dark:text-gray-400" onClick={() => setShowPassword(!showPassword)} aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}>{showPassword ? '🙈' : '👁️'}</button>
             </div>
           </div>
-
-          {error && <p className="auth-error-message">{error}</p>}
-
-          <button type="submit" className="auth-button" disabled={!isFormValid || isLoading}>
-            {isLoading ? 'Iniciando sesión...' : 'Iniciar sesión'}
-          </button>
-
-          <p className="auth-footer">
-            ¿No tienes una cuenta? <a href="/register">Regístrate aquí</a>
-          </p>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button type="submit" className="w-full rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white py-3 font-semibold disabled:opacity-50" disabled={!isFormValid || isLoading}>{isLoading ? 'Iniciando sesión...' : 'Iniciar sesión'}</button>
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400">¿No tienes una cuenta?{' '}<a className="text-indigo-600 hover:text-indigo-700" href="/register">Regístrate aquí</a></p>
         </form>
       </div>
-      <AppFooter />
+      <AppFooter className="mt-6" />
     </div>
   );
 };
 
 export default Login;
-export { Login };

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS configuration and PostCSS
- import Tailwind styles in React entrypoint
- redesign Login page with Tailwind utilities
- bump version to 2.5.8 in docs and footer

## Testing
- `npm test --silent` in `worker`
- `npm run build --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6889712fd6688324ad8a646e370ee387