### PR TITLE
Debug chimuelo github actions failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,10 @@ jobs:
           cd frontend
           # Clean install with error handling
           npm ci --prefer-offline --no-audit
+          # Ensure Rollup WASM setup is completed
+          npm run prepare
+          # Verify WASM setup
+          ls -la node_modules/@rollup/wasm-node/dist/native.js
           
       - name: Show version info
         run: |

--- a/frontend/node_modules/.package-lock.json
+++ b/frontend/node_modules/.package-lock.json
@@ -1047,6 +1047,20 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/wasm-node": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.46.2.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
-        "@rollup/wasm-node": "^4.46.1",
+        "@rollup/wasm-node": "^4.46.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/version.js all && tsc -b && vite build",
+    "build": "node scripts/version.js all && npm run prepare && tsc -b && vite build",
     "build:dev": "tsc -b && vite build",
     "lint": "eslint . --max-warnings 0",
     "preview": "vite preview",
@@ -17,7 +17,8 @@
     "version:minor": "npm version minor --no-git-tag-version",
     "version:major": "npm version major --no-git-tag-version",
     "version:info": "node scripts/version.js all",
-    "postinstall": "node scripts/setup-rollup-wasm.cjs"
+    "postinstall": "node scripts/setup-rollup-wasm.cjs",
+    "prepare": "node scripts/setup-rollup-wasm.cjs"
   },
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
@@ -30,33 +31,33 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@rollup/wasm-node": "^4.46.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/ui": "^3.2.4",
+    "autoprefixer": "^10.4.16",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^25.0.1",
+    "msw": "^2.6.4",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",
-    "@rollup/wasm-node": "^4.46.1",
-    "tailwindcss": "^3.4.4",
-    "postcss": "^8.4.32",
-    "autoprefixer": "^10.4.16",
-    "vitest": "^3.2.4",
-    "@vitest/ui": "^3.2.4",
-    "@vitest/coverage-v8": "^3.2.4",
-    "jsdom": "^25.0.1",
-    "@testing-library/react": "^16.1.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/user-event": "^14.5.2",
-    "msw": "^2.6.4"
+    "vitest": "^3.2.4"
   },
   "buildInfo": {
-    "commitHash": "30ff107fb07427e8358dabeceeb0dc6ab8b95a24",
-    "buildDate": "2025-08-04T12:57:58.546Z",
-    "branch": "cursor/investigate-build-algorithm-failure-713c"
+    "commitHash": "181d3fee227b5c2ef26b42153adffb816eeb8f88",
+    "buildDate": "2025-08-04T13:05:29.650Z",
+    "branch": "cursor/debug-chimuelo-github-actions-failure-f656"
   }
 }

--- a/frontend/scripts/setup-rollup-wasm.cjs
+++ b/frontend/scripts/setup-rollup-wasm.cjs
@@ -1,8 +1,38 @@
 const fs = require('fs');
 const path = require('path');
+
+// Create the target directory structure
 const targetDir = path.join(__dirname, '..', 'node_modules', '@rollup', 'rollup-linux-x64-gnu');
 if (!fs.existsSync(targetDir)) {
   fs.mkdirSync(targetDir, { recursive: true });
 }
-fs.writeFileSync(path.join(targetDir, 'index.js'), "module.exports = require('@rollup/wasm-node/dist/native.js');\n");
-fs.writeFileSync(path.join(targetDir, 'package.json'), JSON.stringify({name:'@rollup/rollup-linux-x64-gnu',version:'4.46.1',main:'index.js'}, null, 2));
+
+// Verify that @rollup/wasm-node is installed
+const wasmNodePath = path.join(__dirname, '..', 'node_modules', '@rollup', 'wasm-node');
+if (!fs.existsSync(wasmNodePath)) {
+  console.error('❌ @rollup/wasm-node not found. Installing...');
+  const { execSync } = require('child_process');
+  try {
+    execSync('npm install @rollup/wasm-node', { cwd: path.join(__dirname, '..'), stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to install @rollup/wasm-node:', error.message);
+    process.exit(1);
+  }
+}
+
+// Create the index.js file that exports the WASM module
+const indexContent = `module.exports = require('@rollup/wasm-node/dist/native.js');\n`;
+fs.writeFileSync(path.join(targetDir, 'index.js'), indexContent);
+
+// Create the package.json for the native module
+const packageJson = {
+  name: '@rollup/rollup-linux-x64-gnu',
+  version: '4.46.1',
+  main: 'index.js',
+  optionalDependencies: {
+    '@rollup/wasm-node': '^4.46.1'
+  }
+};
+fs.writeFileSync(path.join(targetDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+
+console.log('✅ Rollup WASM setup completed');


### PR DESCRIPTION
Fix GitHub Actions build failure by ensuring `@rollup/wasm-node` is correctly installed and linked for Rollup.

The build was failing because the `@rollup/wasm-node` dependency, crucial for Rollup in Linux environments, was not consistently installed or linked, leading to a "module not found" error. This PR enhances the setup script and CI workflow to robustly handle this optional dependency, ensuring it's present and correctly configured before the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a6b06a8-796d-446d-9b71-c4c824817e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a6b06a8-796d-446d-9b71-c4c824817e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>