### PR TITLE
Build failed during artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
           npm run prepare
           # Verify WASM setup
           ls -la node_modules/@rollup/wasm-node/dist/native.js
+          # Debug: Check node_modules structure
+          echo "Checking node_modules structure..."
+          ls -la node_modules/@rollup/
           
       - name: Show version info
         run: |
@@ -51,6 +54,11 @@ jobs:
           cd frontend
           # Build with error handling
           NODE_ENV=production npm run build
+          # Debug: Check if dist directory exists and has content
+          echo "Checking dist directory..."
+          ls -la dist/
+          echo "Checking dist contents..."
+          find dist/ -type f
 
       - name: Prepare for GitHub Pages (disable Jekyll)
         run: |
@@ -63,9 +71,10 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: frontend/dist
+        continue-on-error: false
 
   deploy-worker:
     runs-on: ubuntu-latest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,8 +56,8 @@
     "vitest": "^3.2.4"
   },
   "buildInfo": {
-    "commitHash": "181d3fee227b5c2ef26b42153adffb816eeb8f88",
-    "buildDate": "2025-08-04T13:05:29.650Z",
-    "branch": "cursor/debug-chimuelo-github-actions-failure-f656"
+    "commitHash": "0ee0f5e03105d69b27c886470242e097271840e7",
+    "buildDate": "2025-08-04T13:16:54.915Z",
+    "branch": "cursor/build-failed-during-artifact-upload-642a"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,6 +28,5 @@
     }
   },
   "include": ["src", "src/**/*"],
-  "exclude": ["src/__tests__/**/*"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "exclude": ["src/__tests__/**/*"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "noEmit": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix GitHub Actions build failure due to TypeScript configuration and update artifact upload action.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing with `TS6310` due to an incorrect project reference in `frontend/tsconfig.json` and a missing `noEmit: true` in `frontend/tsconfig.node.json`. This prevented the build step from succeeding, causing the subsequent artifact upload to fail. The PR also updates the `actions/upload-pages-artifact` to v4 and adds debugging steps to the workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-856cf24e-65bc-4d9f-96e6-dcaa814ce5c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-856cf24e-65bc-4d9f-96e6-dcaa814ce5c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>